### PR TITLE
Change release workflow to use new staging bucket for artifacts

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -2,12 +2,9 @@
 name: Release Gantt Chart Artifacts
 
 on:
-  # push:
-  #   tags:
-  #     - 'v*'
   push:
-    branches:
-      - "release-workflow-patch"
+    tags:
+      - 'v*'
 
 env:
   PLUGIN_NAME: opendistroGanttChartKibana

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -61,6 +61,7 @@ jobs:
 
       - name: Upload to S3
         run: |
+          cd kibana/plugins/gantt-chart
           artifact=`ls ./build/*.zip`
           zip_outfile=`basename ${artifact%.zip}-build-${GITHUB_RUN_NUMBER}.zip`
 

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -68,4 +68,4 @@ jobs:
           s3_prefix="s3://staging.artifacts.opendistroforelasticsearch.amazon.com/snapshots/kibana-plugins/gantt-chart/"
 
           echo "Copying ${artifact} to ${s3_prefix}${zip_outfile}"
-          aws s3 cp --quiet $artifact ${s3_prefix}${zip_outfile}
+          aws s3 cp $artifact ${s3_prefix}${zip_outfile}

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -60,6 +60,8 @@ jobs:
         run: |
           cd kibana/plugins/gantt-chart
           artifact=`ls ./build/*.zip`
+          
+          # inject build number before the suffix
           zip_outfile=`basename ${artifact%.zip}-build-${GITHUB_RUN_NUMBER}.zip`
 
           s3_prefix="s3://staging.artifacts.opendistroforelasticsearch.amazon.com/snapshots/kibana-plugins/gantt-chart/"

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -67,5 +67,5 @@ jobs:
 
           s3_prefix="s3://staging.artifacts.opendistroforelasticsearch.amazon.com/snapshots/kibana-plugins/gantt-chart/"
 
-          echo "Copying ${zip} to ${s3_prefix}${zip_outfile}"
-          aws s3 cp --quiet $zip ${s3_prefix}${zip_outfile}
+          echo "Copying ${artifact} to ${s3_prefix}${zip_outfile}"
+          aws s3 cp --quiet $artifact ${s3_prefix}${zip_outfile}

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -68,4 +68,4 @@ jobs:
           s3_prefix="s3://staging.artifacts.opendistroforelasticsearch.amazon.com/snapshots/kibana-plugins/gantt-chart/"
 
           echo "Copying ${artifact} to ${s3_prefix}${zip_outfile}"
-          aws s3 cp $artifact ${s3_prefix}${zip_outfile}
+          aws s3 cp --quiet $artifact ${s3_prefix}${zip_outfile}

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -2,9 +2,12 @@
 name: Release Gantt Chart Artifacts
 
 on:
+  # push:
+  #   tags:
+  #     - 'v*'
   push:
-    tags:
-      - 'v*'
+    branches:
+      - "release-workflow-patch"
 
 env:
   PLUGIN_NAME: opendistroGanttChartKibana
@@ -21,8 +24,8 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_STAGING_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_STAGING_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
 
       - name: Checkout Plugin
@@ -55,7 +58,13 @@ jobs:
           cd kibana/plugins/gantt-chart
           yarn build
           mv ./build/*.zip ./build/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}.zip
-          artifact=`ls ./build/*.zip`
 
-          aws s3 cp $artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/kibana-plugins/opendistro-gantt-chart/
-          aws cloudfront create-invalidation --distribution-id ${{ secrets.DISTRIBUTION_ID }} --paths "/downloads/*"
+      - name: Upload to S3
+        run: |
+          artifact=`ls ./build/*.zip`
+          zip_outfile=`basename ${artifact%.zip}-build-${GITHUB_RUN_NUMBER}.zip`
+
+          s3_prefix="s3://staging.artifacts.opendistroforelasticsearch.amazon.com/snapshots/kibana-plugins/gantt-chart/"
+
+          echo "Copying ${zip} to ${s3_prefix}${zip_outfile}"
+          aws s3 cp --quiet $zip ${s3_prefix}${zip_outfile}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The infrastructure team is separating the production and staging locations into different AWS accounts. Plugins need to modify their workflows to publish to the new locations.

This PR changes the CD workflow to add a build number and write the zip artifact to staging.artifacts.opendistroforelasticsearch.amazon.com.

Test Results: https://github.com/gaiksaya/kibana-visualizations/runs/1692071203?check_suite_focus=true

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
